### PR TITLE
add prefix option to Router (fixes #2)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ declare namespace Router {
   }
   export interface IRouterOptions {
     onMethodNotAllowed?: Router.IMiddleware;
+    prefix?: string;
   }
   export interface IRouterContext extends Koa.Context {
     /**

--- a/router.js
+++ b/router.js
@@ -35,7 +35,7 @@ Router.prototype.on = function(method, path, ...handle) {
   }
 
   if (this.opts.prefix) {
-    path = this.opts.prefix + path
+    path = this.opts.prefix + path;
   }
 
   this.trees[method].addRoute(path, handle);

--- a/router.js
+++ b/router.js
@@ -17,6 +17,10 @@ function Router(opts = {}) {
     return new Router(opts);
   }
 
+  if (opts.prefix && opts.prefix[0] !== "/") {
+    throw new Error("prefix must begin with '/' in path");
+  }
+
   this.trees = {};
   this.opts = opts;
 }
@@ -28,6 +32,10 @@ Router.prototype.on = function(method, path, ...handle) {
 
   if (!this.trees[method]) {
     this.trees[method] = new Node();
+  }
+
+  if (this.opts.prefix) {
+    path = this.opts.prefix + path
   }
 
   this.trees[method].addRoute(path, handle);

--- a/test/integration.js
+++ b/test/integration.js
@@ -66,6 +66,29 @@ describe("Router", () => {
       });
   });
 
+  it("support prefixing all routes", done => {
+    const app = new Koa();
+    const router = new Router({ prefix: '/api' });
+
+    router.get("/", function(ctx) {
+      ctx.body = "ok";
+    });
+
+    router.get("/cars", function(ctx) {
+      ctx.body = "ok";
+    });
+
+    app.use(router.routes());
+
+    request(app.callback())
+      .get("/api/")
+      .expect(200);
+
+    request(app.callback())
+      .get("/api/cars")
+      .expect(200, done);
+  });
+
   it("handle #", done => {
     const app = new Koa();
     const router = new Router();

--- a/test/integration.js
+++ b/test/integration.js
@@ -80,13 +80,16 @@ describe("Router", () => {
 
     app.use(router.routes());
 
-    request(app.callback())
-      .get("/api/")
-      .expect(200);
+    const callback = app.callback();
 
-    request(app.callback())
-      .get("/api/cars")
-      .expect(200, done);
+    request(callback)
+      .get("/api/")
+      .expect(200)
+      .end(() => {
+        request(callback)
+          .get("/api/cars")
+          .expect(200, done);
+      });
   });
 
   it("handle #", done => {


### PR DESCRIPTION
This PR lets you pass a `prefix` option to the `Router` constructor like so:

```js
const router = new Router({ prefix: '/api' })
```

And now when you do something like:

```js
router.get('/cars', async ctx => {
  ctx.body = 'ok'
})
```

It would be the same as doing:

```js
router.get('/api/cars', async ctx => {
  ctx.body = 'ok'
})
```

Let me know if you would like me to make any changes or if you don't want to add any additional options to the router. Either way, thank you for making this!