### PR TITLE
Replace params array with object

### DIFF
--- a/router.js
+++ b/router.js
@@ -3,7 +3,7 @@ const compose = require("koa-compose");
 const Node = require("./tree");
 
 const httpMethods = http.METHODS;
-const NOT_FOUND = { handle: null, params: [] };
+const NOT_FOUND = { handle: null, params: {} };
 
 class Router {
   constructor(opts = {}) {
@@ -93,10 +93,7 @@ class Router {
         }
         return next();
       }
-      ctx.params = {};
-      params.forEach(({ key, value }) => {
-        ctx.params[key] = value;
-      });
+      ctx.params = params;
       return compose(handle)(ctx, next);
     };
     return handle;

--- a/test/tree-spec.js
+++ b/test/tree-spec.js
@@ -132,57 +132,51 @@ describe("Wildcard", () => {
   const foundData = [
     {
       route: "/",
-      params: []
+      params: {}
     },
     {
       route: "/cmd/test/",
-      params: [{ key: "tool", value: "test" }]
+      params: { tool: "test" }
     },
     {
       route: "/cmd/test/3",
-      params: [{ key: "tool", value: "test" }, { key: "sub", value: "3" }]
+      params: { tool: "test", sub: "3" }
     },
     {
       route: "/src/",
-      params: [{ key: "filepath", value: "/" }]
+      params: { filepath: "/" }
     },
     {
       route: "/src/some/file.png",
-      params: [{ key: "filepath", value: "/some/file.png" }]
+      params: { filepath: "/some/file.png" }
     },
     {
       route: "/search/",
-      params: []
+      params: {}
     },
     {
       route: "/search/中文",
-      params: [{ key: "query", value: "中文" }]
+      params: { query: "中文" }
     },
     {
       route: "/user_noder",
-      params: [{ key: "name", value: "noder" }]
+      params: { name: "noder" }
     },
     {
       route: "/user_noder/about",
-      params: [{ key: "name", value: "noder" }]
+      params: { name: "noder" }
     },
     {
       route: "/files/js/inc/framework.js",
-      params: [
-        { key: "dir", value: "js" },
-        { key: "filepath", value: "/inc/framework.js" }
-      ]
+      params: { dir: "js", filepath: "/inc/framework.js" }
     },
     {
       route: "/info/gordon/public",
-      params: [{ key: "user", value: "gordon" }]
+      params: { user: "gordon" }
     },
     {
       route: "/info/gordon/project/node",
-      params: [
-        { key: "user", value: "gordon" },
-        { key: "project", value: "node" }
-      ]
+      params: { user: "gordon", project: "node" }
     }
   ];
 
@@ -197,11 +191,11 @@ describe("Wildcard", () => {
   const noHandlerData = [
     {
       route: "/cmd/test",
-      params: [{ key: "tool", value: "test" }]
+      params: { tool: "test" }
     },
     {
       route: "/search/中文/",
-      params: [{ key: "query", value: "中文" }]
+      params: { query: "中文" }
     }
   ];
 

--- a/tree.js
+++ b/tree.js
@@ -363,7 +363,7 @@ class node {
    */
   search(path) {
     let handle = null;
-    const params = [];
+    const params = {};
     let n = this;
 
     walk: while (true) {
@@ -397,7 +397,7 @@ class node {
               }
 
               // Save param value
-              params.push({ key: n.path.slice(1), value: path.slice(0, end) });
+              params[n.path.slice(1)] = path.slice(0, end);
 
               // We need to go deeper!
               if (end < path.length) {
@@ -416,7 +416,7 @@ class node {
               return { handle, params };
 
             case CATCH_ALL:
-              params.push({ key: n.path.slice(2), value: path });
+              params[n.path.slice(2)] = path;
 
               handle = n.handle;
               return { handle, params };


### PR DESCRIPTION
This is a small optimization. But since we're interested in the params as an object, not as an array, why not collect them as such right away? ~~This then allows the use of `Object.assign()` instead of a custom `forEach()` loop to create `ctx.params`, which may also be faster.~~

*Update:* This copy operation isn't even necessary, because `search()` creates  a new instance of `params` on every execution. This should definitely perform better.