### PR TITLE
Added support for matched pattern

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,39 @@ Pattern: /src/*filepath
  /src/subdir/somefile.go   match
 ```
 
+## Matched patterns
+The `ctx.matched` is set with the request's matched pattern. This is useful for Access Control List (ACL) or any form of validations based on router's template.
+
+```JS
+const aclCheck = function(ctx, next) {
+  // the assumption is that the user's roles are set in context (e.g. ['reader', 'author'])
+  if (ctx.method === 'GET') {
+    if (['/posts', '/posts/:id'].indexOf(ctx.matched) !== -1 && ctx.user.roles.indexOf('reader') !== -1) {
+      // granted
+      return next();
+    }
+  } else if (ctx.method === 'POST') {
+    if (ctx.matched === '/posts' && ctx.user.roles.indexOf('author') !== -1) {
+      // granted
+      return next();
+    }
+  }
+  ctx.status = 403;
+  ctx.body = 'forbidden error';
+};
+
+router
+  .get("/posts", aclCheck, function(ctx) {
+    // your code
+  })
+  .post("/posts", aclCheck, function(ctx) {
+    // your code
+  })
+  .get("/posts/:id", aclCheck, function(ctx) {
+    // your code
+  });
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/router.js
+++ b/router.js
@@ -3,7 +3,7 @@ const compose = require("koa-compose");
 const Node = require("./tree");
 
 const httpMethods = http.METHODS;
-const NOT_FOUND = { handle: null, params: [] };
+const NOT_FOUND = { handle: null, params: [], matched: null };
 
 class Router {
   constructor(opts = {}) {
@@ -72,7 +72,7 @@ class Router {
   routes() {
     const router = this;
     const handle = function(ctx, next) {
-      const { handle, params } = router.find(ctx.method, ctx.path);
+      const { handle, params, matched } = router.find(ctx.method, ctx.path);
       if (!handle) {
         const handle405 = router.opts.onMethodNotAllowed;
         if (handle405) {
@@ -94,6 +94,7 @@ class Router {
         return next();
       }
       ctx.params = {};
+      ctx.matched = matched;
       params.forEach(({ key, value }) => {
         ctx.params[key] = value;
       });

--- a/tree.js
+++ b/tree.js
@@ -363,6 +363,7 @@ class Node {
    */
   search(path) {
     let handle = null;
+    const matched = [];
     const params = [];
     let n = this;
 
@@ -377,16 +378,18 @@ class Node {
             const c = path.charCodeAt(0);
             for (let i = 0; i < n.indices.length; i++) {
               if (c === n.indices.charCodeAt(i)) {
+                matched.push(n.path);
                 n = n.children[i];
                 continue walk;
               }
             }
 
             // Nothing found.
-            return { handle, params };
+            return { handle, params, matched: null };
           }
 
           // Handle wildcard child
+          matched.push(n.path);
           n = n.children[0];
           switch (n.type) {
             case PARAM:
@@ -403,23 +406,26 @@ class Node {
               if (end < path.length) {
                 if (n.children.length > 0) {
                   path = path.slice(end);
+                  matched.push(n.path);
                   n = n.children[0];
                   continue walk;
                 }
 
                 // ... but we can't
-                return { handle, params };
+                return { handle, params, matched: null };
               }
 
               handle = n.handle;
+              matched.push(n.path);
 
-              return { handle, params };
+              return { handle, params, matched: matched.join('') };
 
             case CATCH_ALL:
               params.push({ key: n.path.slice(2), value: path });
 
               handle = n.handle;
-              return { handle, params };
+              matched.push(n.path);
+              return { handle, params, matched: matched.join('') };
 
             default:
               throw new Error("invalid node type");
@@ -427,9 +433,10 @@ class Node {
         }
       } else if (path === n.path) {
         handle = n.handle;
+        matched.push(n.path);
       }
 
-      return { handle, params };
+      return { handle, params, matched: matched.join('') };
     }
   }
 }


### PR DESCRIPTION
The `ctx.matched` will be set with the matched pattern. This is useful for Access Control List (ACL) checks on incoming requests.