### PR TITLE
feat: support Router#use

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,8 @@ app.use(router.routes());
 app.listen(8080);
 ```
 
+Middleware added with `use()` are also added to the nested routes.
+
 #### ctx.params
 This object contains key-value pairs of named route parameters.
 

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,22 @@ If you need a route that supports *all* methods you can use the `all` api.
 router.all(path, middleware)
 ```
 
+#### use(middleware)
+You can add middleware that is added to all future routes:
+```js
+router.use(authMiddleware);
+router.get("/foo", (ctx) => { /* your code */ });
+router.get("/bar", (ctx) => { /* your code */ });
+router.get("/baz", (ctx) => { /* your code */ });
+```
+
+This is equivalent to:
+```js
+router.get("/foo", authMiddleware, (ctx) => { /* your code */ });
+router.get("/bar", authMiddleware, (ctx) => { /* your code */ });
+router.get("/baz", authMiddleware, (ctx) => { /* your code */ });
+```
+
 #### routes
 Returns router middleware.
 

--- a/routegroup.js
+++ b/routegroup.js
@@ -8,7 +8,7 @@ class RouteGroup {
    * @param {*} router
    * @param {string} path
    */
-  constructor(router, path) {
+  constructor(router, path, handlers = []) {
     if (path[0] !== "/") {
       throw new Error("path must begin with '/' in path '" + path + "'");
     }
@@ -16,7 +16,7 @@ class RouteGroup {
     if (path[path.length - 1] === "/") {
       path = path.substr(0, path.length - 1);
     }
-    this.handlers = [];
+    this.handlers = [...handlers];
     this.r = router;
     this.p = path;
   }
@@ -37,7 +37,7 @@ class RouteGroup {
    * @param {string} path
    */
   newGroup(path) {
-    return new RouteGroup(this.r, this.subpath(path));
+    return new RouteGroup(this.r, this.subpath(path), this.handlers);
   }
   on(method, path, ...handle) {
     handle.unshift(...this.handlers);

--- a/routegroup.js
+++ b/routegroup.js
@@ -16,6 +16,7 @@ class RouteGroup {
     if (path[path.length - 1] === "/") {
       path = path.substr(0, path.length - 1);
     }
+    this.handlers = [];
     this.r = router;
     this.p = path;
   }
@@ -39,6 +40,7 @@ class RouteGroup {
     return new RouteGroup(this.r, this.subpath(path));
   }
   on(method, path, ...handle) {
+    handle.unshift(...this.handlers);
     return this.r.on(method, this.subpath(path), ...handle);
   }
   get(...arg) {
@@ -73,6 +75,9 @@ class RouteGroup {
       this.on(method, ...arg);
     });
     return this;
+  }
+  use(...handle) {
+    this.handlers.push(...handle);
   }
   routes() {
     return this.r.routes();

--- a/router.js
+++ b/router.js
@@ -108,7 +108,7 @@ class Router {
    * @param {string} path
    */
   newGroup(path) {
-    return new RouteGroup(this, path);
+    return new RouteGroup(this, path, this.handlers);
   }
 }
 

--- a/router.js
+++ b/router.js
@@ -11,6 +11,7 @@ class Router {
     if (!(this instanceof Router)) {
       return new Router(opts);
     }
+    this.handlers = [];
     this.trees = {};
     this.opts = opts;
   }
@@ -18,6 +19,7 @@ class Router {
     if (path[0] !== "/") {
       throw new Error("path must begin with '/' in path");
     }
+    handle.unshift(...this.handlers);
     if (!this.trees[method]) {
       this.trees[method] = new Node();
     }
@@ -56,6 +58,9 @@ class Router {
       this.on(method, ...arg);
     });
     return this;
+  }
+  use(...handle) {
+    this.handlers.push(...handle);
   }
   find(method, path) {
     const tree = this.trees[method];

--- a/test/routegroup-spec.js
+++ b/test/routegroup-spec.js
@@ -2,7 +2,7 @@ const expect = require("expect");
 const Router = require("../router");
 const RouteGroup = require("../routegroup");
 
-const noOp = [function () {}];
+const noOp = function () {};
 
 describe("Route Group", () => {
   it("works!", () => {
@@ -19,5 +19,14 @@ describe("Route Group", () => {
     group.get("/foo", noOp);
     expect(r.find("POST", "/bar").handle).toBeTruthy();
     expect(r.find("GET", "/bar/foo").handle).toBeTruthy();
+  });
+
+  it("uses middleware from `use` in `on`", () => {
+    const r = new Router();
+    const group = new RouteGroup(r, "/foo");
+    group.use(noOp);
+    group.get("/bar", noOp);
+    expect(r.find("GET", "/foo/bar").handle).toBeTruthy();
+    expect(r.find("GET", "/foo/bar").handle).toHaveLength(2);
   });
 });

--- a/test/router-spec.js
+++ b/test/router-spec.js
@@ -1,7 +1,7 @@
 const expect = require("expect");
 const Router = require("../router");
 
-const noOp = [function() {}];
+const noOp = function() {};
 
 describe("Router", () => {
   it("works!", () => {
@@ -79,5 +79,13 @@ describe("Router", () => {
     expect(router.find("OPTIONS", "/").handle).toBeTruthy();
     expect(router.find("TRACE", "/").handle).toBeTruthy();
     expect(router.find("CONNECT", "/").handle).toBeTruthy();
+  });
+
+  it("uses middleware from `use` in `on`", () => {
+    const router = new Router();
+    router.use(noOp);
+    router.on("GET", "/", noOp);
+    expect(router.find("GET", "/").handle).toBeTruthy();
+    expect(router.find("GET", "/").handle).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Handlers added with `Router#use(...handlers)` and `RouteGroup#use(...handlers)` will be added in all future `Router#[method]()` calls, so:
```js
router.get("/foo", authMiddleware, (ctx) => ctx.body = "foo");
router.get("/bar", authMiddleware, (ctx) => ctx.body = "bar");
router.get("/baz", authMiddleware, (ctx) => ctx.body = "baz");
```
can be replaced with:
```js
router.use(authMiddleware);
router.get("/foo", (ctx) => ctx.body = "foo");
router.get("/bar", (ctx) => ctx.body = "bar");
router.get("/baz", (ctx) => ctx.body = "baz");
```
The handlers are only run on matched routes.

Also fixed the tests, `noOp` should be a function.