### PR TITLE
implemented same path wildcard & static conflict fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Logs
 logs
 *.log

--- a/__tests__/tree-spec.js
+++ b/__tests__/tree-spec.js
@@ -106,8 +106,9 @@ describe("Wildcard", () => {
   const tree = new Tree();
   const routes = [
     "/",
-    "/cmd/:tool/:sub",
+    "/cmd/foo/bar",
     "/cmd/:tool/",
+    "/cmd/:tool/:sub",
     "/src/*filepath",
     "/search/",
     "/search/:query",
@@ -130,6 +131,10 @@ describe("Wildcard", () => {
   const foundData = [
     {
       route: "/",
+      params: []
+    },
+    {
+      route: "/cmd/foo/bar",
       params: []
     },
     {


### PR DESCRIPTION
Short:

- implemented support of having exact route definitions for the same path as wildcard definitions;
- adjusted test to cover the case;
- added .idea to .gitignore;

Notes:

```
/cmd/foo/bar
/cmd/test
/cmd/test/3
```

- In my implementation, exact defs must be added before wildcards, otherwise it will conflict with wildcard.
- Allowed having more than 1 child in a wildcard (besides wildcard itself)
- Added backup stack to the tree search function. That for the following case:
  ```
  Path: /cmd/test/3
  Tree:
  - /cmd
  - -----/foo/bar
  - -----/:p1
  - --------:p2
  -> Goes inside /foo/bar - didn't satisfy
  -> Pops backup from stack, so search starts with /cmd and child offset == 1
  -> Goes inside /:p1
  -> Goes inside /:p2 - FOUND
  ```

Fixes https://github.com/steambap/koa-tree-router/issues/28
Probably fixes: https://github.com/steambap/koa-tree-router/issues/19