### PR TITLE
Method `on` in the RouterGroup returns self

### DIFF
--- a/routegroup.js
+++ b/routegroup.js
@@ -41,7 +41,8 @@ class RouteGroup {
   }
   on(method, path, ...handle) {
     handle.unshift(...this.handlers);
-    return this.r.on(method, this.subpath(path), ...handle);
+    this.r.on(method, this.subpath(path), ...handle);
+    return this;
   }
   get(...arg) {
     return this.on("GET", ...arg);


### PR DESCRIPTION
Right now RouteGroup.on return parent Router.
According to logic and existing TS types, it should return self